### PR TITLE
feat: add gitlab support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Supports parsing SSH/HTTPS repo urls for:
 - GitHub
 - Bitbucket
 - Azure DevOps
+- GitLab
 
 See [tests/parse.rs](tests/parse.rs) for expected output for a variety of inputs.
 

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -156,6 +156,72 @@ fn https_user_auth_github() {
 }
 
 #[test]
+fn https_user_gitlab() {
+    let test_url = "https://user@gitlab.com/user/repo.git";
+    let parsed = GitUrl::parse(test_url).expect("URL parse failed");
+    let expected = GitUrl {
+        host: Some("gitlab.com".to_string()),
+        name: "repo".to_string(),
+        owner: Some("user".to_string()),
+        organization: None,
+        fullname: "user/repo".to_string(),
+        scheme: Scheme::Https,
+        user: Some("user".to_string()),
+        token: None,
+        port: None,
+        path: "/user/repo.git".to_string(),
+        git_suffix: true,
+        scheme_prefix: true,
+    };
+
+    assert_eq!(parsed, expected);
+}
+
+#[test]
+fn ssh_user_gitlab() {
+    let test_url = "git@gitlab.com:user/repo.git";
+    let parsed = GitUrl::parse(test_url).expect("URL parse failed");
+    let expected = GitUrl {
+        host: Some("gitlab.com".to_string()),
+        name: "repo".to_string(),
+        owner: Some("user".to_string()),
+        organization: None,
+        fullname: "user/repo".to_string(),
+        scheme: Scheme::Ssh,
+        user: Some("git".to_string()),
+        token: None,
+        port: None,
+        path: "user/repo.git".to_string(),
+        git_suffix: true,
+        scheme_prefix: false,
+    };
+
+    assert_eq!(parsed, expected);
+}
+
+#[test]
+fn https_user_auth_gitlab() {
+    let test_url = "https://user:glpat-abc@gitlab.com/owner/name.git";
+    let parsed = GitUrl::parse(test_url).expect("URL parse failed");
+    let expected = GitUrl {
+        host: Some("gitlab.com".to_string()),
+        name: "name".to_string(),
+        owner: Some("owner".to_string()),
+        organization: None,
+        fullname: "owner/name".to_string(),
+        scheme: Scheme::Https,
+        user: Some("user".to_string()),
+        token: Some("glpat-abc".to_string()),
+        port: None,
+        path: "/owner/name.git".to_string(),
+        git_suffix: true,
+        scheme_prefix: true,
+    };
+
+    assert_eq!(parsed, expected);
+}
+
+#[test]
 fn ssh_user_azure_devops() {
     let test_url = "git@ssh.dev.azure.com:v3/CompanyName/ProjectName/RepoName";
     let parsed = GitUrl::parse(test_url).expect("URL parse failed");

--- a/tests/trim_auth.rs
+++ b/tests/trim_auth.rs
@@ -79,6 +79,39 @@ fn https_user_auth_github() {
 }
 
 #[test]
+fn https_user_gitlab() {
+    let test_url = "https://user@gitlab.com/user/repo.git/";
+    let parsed_and_trimmed = GitUrl::parse(test_url)
+        .expect("URL parse failed")
+        .trim_auth();
+    let expected = "https://gitlab.com/user/repo.git";
+
+    assert_eq!(format!("{}", parsed_and_trimmed), expected);
+}
+
+#[test]
+fn ssh_user_gitlab() {
+    let test_url = "git@gitlab.com:user/repo.git";
+    let parsed_and_trimmed = GitUrl::parse(test_url)
+        .expect("URL parse failed")
+        .trim_auth();
+    let expected = "gitlab.com:user/repo.git";
+
+    assert_eq!(format!("{}", parsed_and_trimmed), expected);
+}
+
+#[test]
+fn https_user_auth_gitlab() {
+    let test_url = "https://token:x-oauth-basic@gitlab.com/owner/name.git/";
+    let parsed_and_trimmed = GitUrl::parse(test_url)
+        .expect("URL parse failed")
+        .trim_auth();
+    let expected = "https://gitlab.com/owner/name.git";
+
+    assert_eq!(format!("{}", parsed_and_trimmed), expected);
+}
+
+#[test]
 fn ssh_user_azure_devops() {
     let test_url = "git@ssh.dev.azure.com:v3/CompanyName/ProjectName/RepoName";
     let parsed_and_trimmed = GitUrl::parse(test_url)


### PR DESCRIPTION
Added tests for Gitlab urls. They are quite the same as Github URLs, not sure if it even needs separate tests tbh.